### PR TITLE
Cast packCurrent to a short because the current can be negative.

### DIFF
--- a/bms-tian-modbus/src/main/java/com/airepublic/bmstoinverter/bms/tian/modbus/TianBmsModbusProcessor.java
+++ b/bms-tian-modbus/src/main/java/com/airepublic/bmstoinverter/bms/tian/modbus/TianBmsModbusProcessor.java
@@ -57,7 +57,7 @@ public class TianBmsModbusProcessor extends BMS {
         // pack voltage 0.01V
         pack.packVoltage = frame.getInt() / 10;
         // pack current 0.01A
-        pack.packCurrent = frame.getInt() / 10;
+        pack.packCurrent = ((short) frame.getInt()) / 10;
         // remaining capacity 0.01AH
         pack.remainingCapacitymAh = frame.getInt() * 10;
         // average temperature 0.1C


### PR DESCRIPTION
Range is -32k to +32k in 10mA units. e.g. -100 is 10 amps outflow. +200 is 20 amps charging.

Fixes #79 
