### PR TITLE
Remove modbus addr offset for reads from Shoto BMS

### DIFF
--- a/bms-shoto-modbus/src/main/java/com/airepublic/bmstoinverter/bms/shoto/modbus/ShotoBmsModbusProcessor.java
+++ b/bms-shoto-modbus/src/main/java/com/airepublic/bmstoinverter/bms/shoto/modbus/ShotoBmsModbusProcessor.java
@@ -35,13 +35,13 @@ public class ShotoBmsModbusProcessor extends BMS {
     @Override
     protected void collectData(final Port port) {
         try {
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x0001, 1, getBmsId(), this::readBatteryVoltage);
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x0005, 2, getBmsId(), this::readCellMinMaxTemperature);
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x0012, 32, getBmsId(), this::readCellVoltageAndTemperature);
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x0101, 2, getBmsId(), this::readHardwareSoftwareVersion);
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x010F, 1, getBmsId(), this::readNumberOfCells);
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x1010, 1, getBmsId(), this::readMaxDischargeVoltage);
-            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 30000 + 0x1031, 18, getBmsId(), this::readBatteryStatus);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x0001, 1, getBmsId(), this::readBatteryVoltage);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x0005, 2, getBmsId(), this::readCellMinMaxTemperature);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x0012, 32, getBmsId(), this::readCellVoltageAndTemperature);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x0101, 2, getBmsId(), this::readHardwareSoftwareVersion);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x010F, 1, getBmsId(), this::readNumberOfCells);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x1010, 1, getBmsId(), this::readMaxDischargeVoltage);
+            sendMessage(port, RegisterCode.READ_HOLDING_REGISTERS, 0x1031, 18, getBmsId(), this::readBatteryStatus);
         } catch (final IOException e) {
             LOG.error("Error reading from modbus!", e);
         }


### PR DESCRIPTION
As noted in my [comment](https://github.com/ai-republic/bms-to-inverter/issues/96#issuecomment-2648270415), I think we don't want the offsets to the register addresses for reads from this BMS.  I am not able to compile this myself to test it so will wait for the next SNAPSHOT to test.

