### PR TITLE
fix: wayland dialog rendering issues by adding pack()

### DIFF
--- a/configurator/src/main/java/com/airepublic/bmstoinverter/configurator/BMSDialog.java
+++ b/configurator/src/main/java/com/airepublic/bmstoinverter/configurator/BMSDialog.java
@@ -59,7 +59,7 @@ public class BMSDialog extends JDialog {
         descriptors = createBMSDescriptors();
 
         setLocation(configurator.getBounds().width / 2 - 175, configurator.getBounds().height / 2 - 60);
-        setSize(new Dimension(350, 359));
+        setPreferredSize(new Dimension(350, 359));
         setResizable(false);
         getContentPane().setLayout(new BorderLayout(0, 0));
 
@@ -220,6 +220,7 @@ public class BMSDialog extends JDialog {
         gbc_cancelButton.gridy = 0;
         buttonPanel.add(cancelButton, gbc_cancelButton);
 
+        pack();
         setLocationRelativeTo(null);
     }
 

--- a/configurator/src/main/java/com/airepublic/bmstoinverter/configurator/InstallationDialog.java
+++ b/configurator/src/main/java/com/airepublic/bmstoinverter/configurator/InstallationDialog.java
@@ -46,7 +46,7 @@ public class InstallationDialog extends JDialog {
     public InstallationDialog(final JFrame frame) {
         super(frame, "Installing...", true);
         setLocation(frame.getX() + frame.getBounds().width / 2 - 320, frame.getY() + frame.getBounds().height / 2 - 240);
-        setSize(new Dimension(640, 480));
+        setPreferredSize(new Dimension(640, 480));
         getContentPane().setLayout(new BorderLayout(0, 0));
 
         final JPanel panel = new JPanel();
@@ -83,6 +83,9 @@ public class InstallationDialog extends JDialog {
         gbc_closeButton.gridy = 1;
         panel.add(closeButton, gbc_closeButton);
         closeButton.addActionListener(e -> dispose());
+        
+        pack();
+        setLocationRelativeTo(null);
     }
 
 

--- a/configurator/src/main/java/com/airepublic/bmstoinverter/configurator/PluginDialog.java
+++ b/configurator/src/main/java/com/airepublic/bmstoinverter/configurator/PluginDialog.java
@@ -54,7 +54,7 @@ public class PluginDialog extends JDialog {
         super(configurator, "Plugin configuration...", true);
 
         setLocation(configurator.getBounds().width / 2 - 250, configurator.getBounds().height / 2 - 60);
-        setSize(new Dimension(500, 450));
+        setPreferredSize(new Dimension(500, 450));
         setResizable(false);
         getContentPane().setLayout(new BorderLayout(5, 5));
 
@@ -120,6 +120,7 @@ public class PluginDialog extends JDialog {
             propertiesScrollPane.validate();
         });
 
+        pack();
         setLocationRelativeTo(null);
     }
 


### PR DESCRIPTION
Hi there. Unfortunately under Linux Wayland I had the following problem:
<img width="954" height="973" alt="image" src="https://github.com/user-attachments/assets/fd5af199-c5f6-460c-b343-432fce29d905" />

Any popout window was just gray.
This PR should fix this using `pack()`

the change to `setPreferredSize` was necessary because `pack()` packed the dialog to only have the width of the smallest control panels added.



DISCLAIMER: I am no Java developer, but C and Rust headless embedded. This fix has been implemented by Gemini only and I verified on my linux system that the dialogs are now rendering as they should. I unfortunately have no Windows at hand to test if they work there as well.